### PR TITLE
Clarifies ruleset import instructions in setup steps

### DIFF
--- a/.github/rulesets/branches/main.json
+++ b/.github/rulesets/branches/main.json
@@ -1,0 +1,64 @@
+{
+  "id": 6732598,
+  "name": "main",
+  "target": "branch",
+  "source_type": "Repository",
+  "source": "EED-Solutions/eed_package_template",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~DEFAULT_BRANCH"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          {
+            "context": "pytests / callable_pytests (3.13)",
+            "integration_id": 15368
+          },
+          {
+            "context": "ruff / callable_ruff",
+            "integration_id": 15368
+          }
+        ]
+      }
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": true,
+        "require_last_push_approval": true,
+        "required_review_thread_resolution": false,
+        "automatic_copilot_code_review_enabled": false,
+        "allowed_merge_methods": [
+          "merge",
+          "squash",
+          "rebase"
+        ]
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "pull_request"
+    }
+  ]
+}

--- a/.github/rulesets/tags/semantic versioning.json
+++ b/.github/rulesets/tags/semantic versioning.json
@@ -1,0 +1,59 @@
+{
+  "id": 6732884,
+  "name": "semantic versioning",
+  "target": "tag",
+  "source_type": "Repository",
+  "source": "EED-Solutions/eed_package_template",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "refs/tags/*.*.*"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "creation"
+    },
+    {
+      "type": "update"
+    },
+    {
+      "type": "required_signatures"
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          {
+            "context": "ruff",
+            "integration_id": 15368
+          },
+          {
+            "context": "pytests (3.11)",
+            "integration_id": 15368
+          },
+          {
+            "context": "pytests (3.12)",
+            "integration_id": 15368
+          },
+          {
+            "context": "pytests (3.13)",
+            "integration_id": 15368
+          }
+        ]
+      }
+    }
+  ],
+  "bypass_actors": []
+}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 8. Rename the directory `src/eed_package_template` to match your new package name (e.g., `src/eed_my_new_package`).
 9. Use VS Code's find and replace feature to update all instances of `eed_package_template` with your new package name.
 10. Commit all changes, create a pull request, and ensure all CI pipelines pass.
-11. Update repository settings as needed (e.g., import branch/tag rulesets, general settings). For more information, see [this guide](https://eed-solutions.atlassian.net/wiki/x/BIA8Mw) (private access).
+11. Update repository settings as needed (e.g., import branch/tag rulesets, general settings). For more information, see [this guide](https://eed-solutions.atlassian.net/wiki/x/BIA8Mw) (private access). Rulesets are documented under ``.github\rulesets`` and can be imported.
 12. Merge the pull request and create the initial release (e.g., `0.1.0`).
 
 ## Other


### PR DESCRIPTION
Explains that rulesets are documented under the relevant directory
and can be imported during repository setup, improving guidance
for repository configuration.
